### PR TITLE
reportlib.graphics.shapes no longer import string

### DIFF
--- a/src/svglib/svglib.py
+++ b/src/svglib/svglib.py
@@ -18,6 +18,7 @@ pressed with gzip and extension .svgz).
 import sys
 import os
 import glob
+import string
 import types
 import re
 import operator


### PR DESCRIPTION
Updated file here. Import string explicitly to use the string library.

https://bitbucket.org/rptlab/reportlab/src/7c45177d8a774fd6cd8e1ef8bc4374a8e862ec8a/src/reportlab/graphics/shapes.py?at=default&fileviewer=file-view-default
